### PR TITLE
Fix state information box height #31

### DIFF
--- a/src/scss/ces.scss
+++ b/src/scss/ces.scss
@@ -58,8 +58,8 @@ td.inactive, .table > thead > tr > th.inactive, .table > thead > tr.inactive > t
 
 /* States */
 .state {
-  padding-bottom: 5vh;
   margin-bottom: 0;
+  height: 65px;
 }
 
 .stateText {


### PR DESCRIPTION
set the box to a fixed height to preserve ratios and paddings.
Resolves #31 